### PR TITLE
Setup global shortcut

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,3 +25,6 @@ If you installed JSDoc globally, run the `jsdoc` command:
 
 By default, the generated documentation is saved in a directory named `out`. You can use the `--destination` (`-d`) option to specify another directory.
 
+## Global shortcut
+
+When the app is running, press `Ctrl+Meta+T` to show the app.

--- a/application/main.js
+++ b/application/main.js
@@ -1,4 +1,4 @@
-const { app, BrowserWindow, ipcMain } = require('electron');
+const { app, BrowserWindow, ipcMain, globalShortcut } = require('electron');
 const path = require('node:path');
 
 let mainWindow;
@@ -42,4 +42,13 @@ app.whenReady().then(() => {
   ipcMain.handle('delete-task', (event, index) => {
     tasks.splice(index, 1);
   });
+
+  // Setup global shortcut Ctrl+Meta+T to show the app
+  const ret = globalShortcut.register('CmdOrCtrl+Meta+T', () => {
+    mainWindow.show();
+    mainWindow.focus();
+  });
+  if (!ret) {
+    console.log('Could not register global shortcut.');
+  }
 });


### PR DESCRIPTION
We choose `Ctrl+Meta+T` to activate the app.