### PR TITLE
Add global shortcut and tray icon

### DIFF
--- a/application/main.js
+++ b/application/main.js
@@ -1,4 +1,4 @@
-const { app, BrowserWindow, ipcMain } = require('electron');
+const { app, BrowserWindow, ipcMain, globalShortcut } = require('electron');
 const path = require('node:path');
 
 let mainWindow;
@@ -52,4 +52,13 @@ app.whenReady().then(() => {
     tasks[quadrant].splice(index, 1); // Remove task from the specified quadrant
     return tasks;
   });
+
+  // Setup global shortcut Ctrl+Alt+T to show the app
+  const ret = globalShortcut.register('CmdOrCtrl+Alt+T', () => {
+    mainWindow.show();
+    mainWindow.focus();
+  });
+  if (!ret) {
+    console.log('Could not register global shortcut.');
+  }
 });


### PR DESCRIPTION
Use Control+Alt+T (should be Command+Alt+T on Mac) to show the window. The app is minimized to tray when the window is closed; click "Quit" in the tray menu to close the app.

@Admiral-Monferrat @McSohan Please help me verify if this functionality works on MacOS and Windows.

Closes #39 